### PR TITLE
仕様変更（楽天APIでの書籍投稿から、通常の画像投稿へ切り替え）

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,6 @@
 
 # Ignore master key for decrypting credentials and more.
 /config/master.key
+
+# Ignore uploaded files in development
+/public/uploads/

--- a/Gemfile
+++ b/Gemfile
@@ -82,3 +82,5 @@ gem 'devise'
 
 gem 'carrierwave'
 gem 'mini_magick'
+gem 'enum_help'
+gem 'rails-i18n'

--- a/Gemfile
+++ b/Gemfile
@@ -79,3 +79,6 @@ gem 'haml-rails'
 gem 'rakuten_web_service'
 
 gem 'devise'
+
+gem 'carrierwave'
+gem 'mini_magick'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -100,6 +100,8 @@ GEM
       railties (>= 4.1.0)
       responders
       warden (~> 1.2.3)
+    enum_help (0.0.17)
+      activesupport (>= 3.0.0)
     erubi (1.9.0)
     erubis (2.7.0)
     execjs (2.7.0)
@@ -182,6 +184,9 @@ GEM
       nokogiri (>= 1.6)
     rails-html-sanitizer (1.3.0)
       loofah (~> 2.3)
+    rails-i18n (5.1.3)
+      i18n (>= 0.7, < 2)
+      railties (>= 5.0, < 6)
     railties (5.2.4.3)
       actionpack (= 5.2.4.3)
       activesupport (= 5.2.4.3)
@@ -276,6 +281,7 @@ DEPENDENCIES
   carrierwave
   coffee-rails (~> 4.2)
   devise
+  enum_help
   haml-rails
   jbuilder (~> 2.5)
   listen (>= 3.0.5, < 3.2)
@@ -284,6 +290,7 @@ DEPENDENCIES
   pry-rails
   puma (~> 3.11)
   rails (~> 5.2.4, >= 5.2.4.3)
+  rails-i18n
   rakuten_web_service
   sassc-rails
   selenium-webdriver

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -76,6 +76,13 @@ GEM
       rack-test (>= 0.6.3)
       regexp_parser (~> 1.5)
       xpath (~> 3.2)
+    carrierwave (2.1.0)
+      activemodel (>= 5.0.0)
+      activesupport (>= 5.0.0)
+      addressable (~> 2.6)
+      image_processing (~> 1.1)
+      mimemagic (>= 0.3.0)
+      mini_mime (>= 0.1.3)
     childprocess (3.0.0)
     coderay (1.1.2)
     coffee-rails (4.2.2)
@@ -115,6 +122,9 @@ GEM
       ruby_parser (~> 3.5)
     i18n (1.8.2)
       concurrent-ruby (~> 1.0)
+    image_processing (1.11.0)
+      mini_magick (>= 4.9.5, < 5)
+      ruby-vips (>= 2.0.17, < 3)
     jbuilder (2.10.0)
       activesupport (>= 5.0.0)
     kgio (2.11.3)
@@ -131,6 +141,7 @@ GEM
       mimemagic (~> 0.3.2)
     method_source (1.0.0)
     mimemagic (0.3.5)
+    mini_magick (4.10.1)
     mini_mime (1.0.2)
     mini_portile2 (2.4.0)
     minitest (5.14.1)
@@ -187,6 +198,8 @@ GEM
     responders (3.0.1)
       actionpack (>= 5.0)
       railties (>= 5.0)
+    ruby-vips (2.0.17)
+      ffi (~> 1.9)
     ruby_dep (1.5.0)
     ruby_parser (3.14.2)
       sexp_processor (~> 4.9)
@@ -260,11 +273,13 @@ DEPENDENCIES
   capistrano-rbenv
   capistrano3-unicorn
   capybara (>= 2.15)
+  carrierwave
   coffee-rails (~> 4.2)
   devise
   haml-rails
   jbuilder (~> 2.5)
   listen (>= 3.0.5, < 3.2)
+  mini_magick
   mysql2 (>= 0.4.4, < 0.6.0)
   pry-rails
   puma (~> 3.11)

--- a/README.md
+++ b/README.md
@@ -1,24 +1,47 @@
-# README
+# 概要
+購入した書籍を登録・管理するアプリです。
+書籍情報をアプリに保存し、読書のアウトプット、読書記録管理を目的に作成しました。
 
-This README would normally document whatever steps are necessary to get the
-application up and running.
+# DB設計
+＜作成中＞
 
-Things you may want to cover:
+## 制作背景
+昔から本を読むことが好きで、書籍に関するアプリ作成を思い立ちました。
+自分自身、読書好きの人は、他人がどんな本を読んで、どんな箇所に興味を持ったのか？について関心があると感じていたので、その関心をお互いに共有、シェアできるアプリを開発してみたいと思い、作成を開始しました。
 
-* Ruby version
+また、電子書籍での読書機会が増え、どの書籍をいつ購入したか、管理する意味でも、読書管理を目に見える形で行えることを大切に開発を行っています。
 
-* System dependencies
+# 機能一覧
+・ユーザー登録、編集機能
+・ログイン、ログアウト機能
+・本の登録、編集、削除機能
 
-* Configuration
+＜実装予定＞
+・感想の登録・編集・削除
+・読みたい書籍リスト登録・削除
+・ユーザーフォロー機能
+・検索機能
+・読書履歴の確認
+・フォローユーザーの新規登録の通知機能
 
-* Database creation
+# 使用技術
+## フロントサイド
+・HTML (haml)
+・css (sass)
+・JavaScript (Jquery)
 
-* Database initialization
+## バックエンド
+・Ruby (2.5.1)
+・Rails (5.2.3)
 
-* How to run the test suite
+## ユーザー関連
+・device
 
-* Services (job queues, cache servers, search engines, etc.)
+## 画像関連
+・carrierwave
 
-* Deployment instructions
+## デプロイ
+.AWS EC2 S3
 
-* ...
+
+

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -6,7 +6,7 @@ class ApplicationController < ActionController::Base
   protected
 
   def configure_permitted_parameters
-    devise_parameter_sanitizer.permit(:sign_up, keys: [:nickname])
+    devise_parameter_sanitizer.permit(:sign_up, keys: [:nickname,:birth_day])
   end
 
   private

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -6,7 +6,7 @@ class ApplicationController < ActionController::Base
   protected
 
   def configure_permitted_parameters
-    devise_parameter_sanitizer.permit(:sign_up, keys: [:nickname,:birth_day])
+    devise_parameter_sanitizer.permit(:sign_up, keys: [:nickname,:image,:birth_day])
   end
 
   private

--- a/app/controllers/books_controller.rb
+++ b/app/controllers/books_controller.rb
@@ -13,7 +13,7 @@ class BooksController < ApplicationController
   end
 
   def create
-    params[:book][:buy_date] = @buy_date.to_s
+    # params[:book][:buy_date] = @buy_date.to_s
     @book = Book.new(book_params)
     @book.save!(book_params)
     redirect_to root_path
@@ -53,23 +53,23 @@ class BooksController < ApplicationController
     ).merge(user_id: current_user.id)
   end
 
-  def read(result)
-    title = result['title']
-    author = result['author']
-    url = result['itemUrl']
-    isbn = result['isbn']
-    publisher_name = result['publisherName']
-    image_url = result['mediumImageUrl'].gsub('?_ex=120x120', '')
+  # def read(result)
+  #   title = result['title']
+  #   author = result['author']
+  #   url = result['itemUrl']
+  #   isbn = result['isbn']
+  #   publisher_name = result['publisherName']
+  #   image_url = result['mediumImageUrl'].gsub('?_ex=120x120', '')
 
-    {
-      title: title,
-      author: author,
-      url: url,
-      isbn: isbn,
-      publisher_name: publisher_name,
-      image_url: image_url
-    }
+  #   {
+  #     title: title,
+  #     author: author,
+  #     url: url,
+  #     isbn: isbn,
+  #     publisher_name: publisher_name,
+  #     image_url: image_url
+  #   }
 
-  end
+  # end
 
 end

--- a/app/controllers/books_controller.rb
+++ b/app/controllers/books_controller.rb
@@ -9,36 +9,13 @@ class BooksController < ApplicationController
   end
 
   def new
-    @books = []
-
-    @title = params[:title]
-    if @title.present?
-      results = RakutenWebService::Books::Book.search({
-        title: @title,
-        hits: 20,
-      })
-
-      results.each do |result|
-        book = Book.new(read(result))
-        @books << book
-      end
-    end
+    @book = Book.new
   end
 
   def create
-    # @book = Book.find_or_initialize_by(isbn: params[:isbn])
-
-    # binding.pry
-
-    # unless @book.persisted?
-    #   results = RakutenWebService::Books::Book.search(isbn: @book.isbn)
-    #   @book = Book.new(read(results.first), books_params)
-    #   @book.save
-    #   redirect_to root_path
-    # end
-
-    @book = Book.new(books_params)
-    @book.save
+    params[:book][:buy_date] = @buy_date.to_s
+    @book = Book.new(book_params)
+    @book.save!(book_params)
     redirect_to root_path
  end
 
@@ -61,8 +38,15 @@ class BooksController < ApplicationController
   # end
 
   private
-  def books_params
-    params.permit(:image_url, :title, :author, :publisher_name, :isbn,:url).merge(user_id: current_user.id)
+  def book_params
+    params.require(:book).permit(
+      :title,
+      :author,
+      :publisher,
+      :category,
+      :buy_date,
+      :image
+    ).merge(user_id: current_user.id)
   end
 
   def read(result)

--- a/app/controllers/books_controller.rb
+++ b/app/controllers/books_controller.rb
@@ -20,9 +20,13 @@ class BooksController < ApplicationController
  end
 
   def edit
+    @book = Book.find(params[:id])
   end
 
   def update
+    @book = Book.find(params[:id]) 
+    @book.update(book_params)
+    redirect_to root_path
   end
 
   def destroy

--- a/app/controllers/books_controller.rb
+++ b/app/controllers/books_controller.rb
@@ -43,14 +43,13 @@ class BooksController < ApplicationController
 
   private
   def book_params
-    params.require(:book).permit(
-      :title,
-      :author,
-      :publisher,
-      :category,
-      :buy_date,
-      :image
-    ).merge(user_id: current_user.id)
+    params.require(:book).permit(:title,
+                                  :author,
+                                  :publisher,
+                                  :category,
+                                  :buy_date,
+                                  :image
+                                ).merge(user_id: current_user.id)
   end
 
   # def read(result)

--- a/app/models/book.rb
+++ b/app/models/book.rb
@@ -1,4 +1,6 @@
 class Book < ApplicationRecord
   belongs_to :user
 
+  mount_uploader :image, ImageUploader
+
 end

--- a/app/models/book.rb
+++ b/app/models/book.rb
@@ -3,4 +3,32 @@ class Book < ApplicationRecord
 
   mount_uploader :image, ImageUploader
 
+  validates :title, presence: true
+  validates :author, presence: true
+  validates :publisher, presence: true
+  validates :status, presence: true
+  validates :buy_date, presence: true
+  # validates :buy_date, date: true, allow_blank: true
+  validates :category,
+            inclusion: { in: ["novel",
+                              "management",
+                              "economy",
+                              "finance",
+                              "history",
+                              "motivation",
+                              "comic",
+                              "etc"] }
+
+  enum category: {
+    "-----": 0,
+    novel: 1,
+    management: 2,
+    economy: 3,
+    finance: 4,
+    history: 5,
+    motivation: 6,
+    comic: 7,
+    etc: 8
+  }, _prefix: true
+
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -5,4 +5,6 @@ class User < ApplicationRecord
          :recoverable, :rememberable, :validatable
   
   has_many :books
+  
+  mount_uploader :image, ImageUploader
 end

--- a/app/uploaders/image_uploader.rb
+++ b/app/uploaders/image_uploader.rb
@@ -1,0 +1,49 @@
+class ImageUploader < CarrierWave::Uploader::Base
+  # Include RMagick or MiniMagick support:
+  # include CarrierWave::RMagick
+  include CarrierWave::MiniMagick
+
+  process resize_to_fit: [300, 300]
+
+  # Choose what kind of storage to use for this uploader:
+  storage :file
+  # storage :fog
+
+  # Override the directory where uploaded files will be stored.
+  # This is a sensible default for uploaders that are meant to be mounted:
+  def store_dir
+    "uploads/#{model.class.to_s.underscore}/#{mounted_as}/#{model.id}"
+  end
+
+  # Provide a default URL as a default if there hasn't been a file uploaded:
+  # def default_url(*args)
+  #   # For Rails 3.1+ asset pipeline compatibility:
+  #   # ActionController::Base.helpers.asset_path("fallback/" + [version_name, "default.png"].compact.join('_'))
+  #
+  #   "/images/fallback/" + [version_name, "default.png"].compact.join('_')
+  # end
+
+  # Process files as they are uploaded:
+  # process scale: [200, 300]
+  #
+  # def scale(width, height)
+  #   # do something
+  # end
+
+  # Create different versions of your uploaded files:
+  # version :thumb do
+  #   process resize_to_fit: [50, 50]
+  # end
+
+  # Add a white list of extensions which are allowed to be uploaded.
+  # For images you might use something like this:
+  # def extension_whitelist
+  #   %w(jpg jpeg gif png)
+  # end
+
+  # Override the filename of the uploaded files:
+  # Avoid using model.id or version_name here, see uploader/store.rb for details.
+  # def filename
+  #   "something.jpg" if original_filename
+  # end
+end

--- a/app/views/books/_book.html.haml
+++ b/app/views/books/_book.html.haml
@@ -37,46 +37,38 @@
     -#   - @book.errors.full_messages_for(:category).each do |message|
     -#     %div
     -#       = message
-    .book-detail__buydate-input
-      = f.date_select :buy_date, {}, class: ""
-      -# = sprintf(f.date_select(:buy_date, prefix:'buy_date', with_css_classes:'select-box', selected: Date.today,use_month_numbers:true, start_year:Time.now.year, end_year:Time.now.year-10, date_separator:'%s'),'年','月')+'日'
+
+    - if params[:controller] == "books" && params[:action] == "new" || params[:controller] == "books" && params[:action] == "create"
+      .book-detail__top.form-content
+        購入日
+      .book-detail__buydate-input
+        = f.date_select :buy_date, {}, class: ""
+        -# != sprintf(f.date_select(:buy_date, prefix:'buy_date', with_css_classes:'select-box', selected: Date.today,use_month_numbers:true, start_year:Time.now.year, end_year:Time.now.year-10, date_separator:'%s'),'年','月')+'日'
+      -# .error-text
+      -#   - @book.errors.full_messages_for(:buy_date).each do |message|
+      -#     %div
+      -#       = message
+    - else
+      .book-detail__top.form-content
+        購入日
+      .book-detail__buydate-input
+        = f.date_select :buy_date, {}, selected: @book.buy_date,class: ""
+        -# != sprintf(f.date_select(:buy_date, prefix:'buy_date', with_css_classes:'select-box', selected: @book.buy_date,use_month_numbers:true, start_year:Time.now.year, end_year:Time.now.year-10, date_separator:'%s'),'年','月')+'日'
+      -# .error-text
+      -#   - @book.errors.full_messages_for(:buy_date).each do |message|
+      -#     %div
+      -#       = message
+  - if params[:controller] == "books" && params[:action] == "new" || params[:controller] == "books" && params[:action] == "create"
     .btn-box
       .btn-box__book-new
         = f.submit " 本を登録する ", class: "submit-btn text-line-none"
       .btn-box__back
         = link_to :back, class: "white-btn margin-left-40 text-line-none" do
           もどる
-
-
-  -#   - if params[:controller] == "books" && params[:action] == "new" || params[:controller] == "books" && params[:action] == "create"
-  -#     .book-detail__top.form-content
-  -#       購入日
-  -#     .book-detail__buydate-input
-  -#       != sprintf(f.date_select(:buy_date, prefix:'buy_date', with_css_classes:'select-box', selected: Date.today,use_month_numbers:true, start_year:Time.now.year, end_year:Time.now.year-10, date_separator:'%s'),'年','月')+'日'
-  -#     .error-text
-  -#       - @book.errors.full_messages_for(:buy_date).each do |message|
-  -#         %div
-  -#           = message
-  -#   - else
-  -#     .book-detail__top.form-content
-  -#       購入日
-  -#     .book-detail__buydate-input
-  -#       != sprintf(f.date_select(:buy_date, prefix:'buy_date', with_css_classes:'select-box', selected: @book.buy_date,use_month_numbers:true, start_year:Time.now.year, end_year:Time.now.year-10, date_separator:'%s'),'年','月')+'日'
-  -#     .error-text
-  -#       - @book.errors.full_messages_for(:buy_date).each do |message|
-  -#         %div
-  -#           = message
-  -# - if params[:controller] == "books" && params[:action] == "new" || params[:controller] == "books" && params[:action] == "create"
-  -#   .btn-box
-  -#     .btn-box__book-new
-  -#       = f.submit " 本を登録する ", class: "submit-btn text-line-none"
-  -#     .btn-box__back
-  -#       = link_to :back, class: "white-btn margin-left-40 text-line-none" do
-  -#         もどる
-  -# - else
-  -#   .btn-box
-  -#     .btn-box__book-new
-  -#       = f.submit " 編集を登録する ", class: "submit-btn text-line-none"
-  -#     .btn-box__back
-  -#       = link_to :back, class: "white-btn margin-left-40 text-line-none" do
-  -#         もどる  
+  - else
+    .btn-box
+      .btn-box__book-new
+        = f.submit " 編集を登録する ", class: "submit-btn text-line-none"
+      .btn-box__back
+        = link_to :back, class: "white-btn margin-left-40 text-line-none" do
+          もどる  

--- a/app/views/books/_book.html.haml
+++ b/app/views/books/_book.html.haml
@@ -1,25 +1,82 @@
-.search-result
-  %p 書籍検索結果
-  .books
-    - @books.each do |book|
-      = form_with model: @book, url: books_path, method: :post, local: true do |f|
-        .content
-          .content__image
-            = link_to (image_tag(book.image_url)), book.url, class: 'content__image__img'
-          .content__in
-            .content__in__title
-              = book.title
-            .content__in__author
-              = "著者：#{book.author}"
-            .content__in__explain
-              = "出版社：#{book.publisher_name}"
-              = f.hidden_field :isbn, value: "#{book.isbn}"
-              = f.hidden_field :url, value:  "#{book.url}"
-              = f.hidden_field :image_url, value: "#{book.image_url}"
-              = f.hidden_field :title, value: "#{book.title}"
-              = f.hidden_field :author, value: "#{book.author}"
-              = f.hidden_field :publisher_name, value: "#{book.publisher_name}"
-              = f.submit 'Save Book'
+= form_with(model: @book, local: true) do |f|
+  .book-image
+    .book-image__top.form-content
+      写真のアップロード
+    .book-image__photo
+      = f.file_field :image
+  .book-detail
+    .book-detail__top.form-content
+      タイトル
+    .book-detail__title-input
+      = f.text_field :title, placeholder: "title", class:"text-input"
+    -# .error-text
+    -#   - @book.errors.full_messages_for(:title).each do |message|
+    -#     %div
+    -#       = message
+    .book-detail__top.form-content
+      著者
+    .book-detail__author-input
+      = f.text_field :author, placeholder: "author", class:"text-input"
+    -# .error-text
+    -#   - @book.errors.full_messages_for(:author).each do |message|
+    -#     %div
+    -#       = message
+    .book-detail__top.form-content
+      出版社
+    .book-detail__publisher-input
+      = f.text_field :publisher, placeholder: "> publisher", class:"text-input"
+    -# .error-text
+    -#   - @book.errors.full_messages_for(:publisher).each do |message|
+    -#     %div
+    -#       = message
+    .book-detail__top.form-content
+      ジャンル
+    .book-detail__category-input
+      = f.select :category, options_for_select(Book.categories.keys.map {|k| [I18n.t("enums.book.category.#{k}"), k]}, selected: @book.category), {}, {class: 'select-box'}
+    -# .error-text
+    -#   - @book.errors.full_messages_for(:category).each do |message|
+    -#     %div
+    -#       = message
+    .book-detail__buydate-input
+      = f.date_select :buy_date, {}, class: ""
+      -# = sprintf(f.date_select(:buy_date, prefix:'buy_date', with_css_classes:'select-box', selected: Date.today,use_month_numbers:true, start_year:Time.now.year, end_year:Time.now.year-10, date_separator:'%s'),'年','月')+'日'
+    .btn-box
+      .btn-box__book-new
+        = f.submit " 本を登録する ", class: "submit-btn text-line-none"
+      .btn-box__back
+        = link_to :back, class: "white-btn margin-left-40 text-line-none" do
+          もどる
 
-            
-          
+
+  -#   - if params[:controller] == "books" && params[:action] == "new" || params[:controller] == "books" && params[:action] == "create"
+  -#     .book-detail__top.form-content
+  -#       購入日
+  -#     .book-detail__buydate-input
+  -#       != sprintf(f.date_select(:buy_date, prefix:'buy_date', with_css_classes:'select-box', selected: Date.today,use_month_numbers:true, start_year:Time.now.year, end_year:Time.now.year-10, date_separator:'%s'),'年','月')+'日'
+  -#     .error-text
+  -#       - @book.errors.full_messages_for(:buy_date).each do |message|
+  -#         %div
+  -#           = message
+  -#   - else
+  -#     .book-detail__top.form-content
+  -#       購入日
+  -#     .book-detail__buydate-input
+  -#       != sprintf(f.date_select(:buy_date, prefix:'buy_date', with_css_classes:'select-box', selected: @book.buy_date,use_month_numbers:true, start_year:Time.now.year, end_year:Time.now.year-10, date_separator:'%s'),'年','月')+'日'
+  -#     .error-text
+  -#       - @book.errors.full_messages_for(:buy_date).each do |message|
+  -#         %div
+  -#           = message
+  -# - if params[:controller] == "books" && params[:action] == "new" || params[:controller] == "books" && params[:action] == "create"
+  -#   .btn-box
+  -#     .btn-box__book-new
+  -#       = f.submit " 本を登録する ", class: "submit-btn text-line-none"
+  -#     .btn-box__back
+  -#       = link_to :back, class: "white-btn margin-left-40 text-line-none" do
+  -#         もどる
+  -# - else
+  -#   .btn-box
+  -#     .btn-box__book-new
+  -#       = f.submit " 編集を登録する ", class: "submit-btn text-line-none"
+  -#     .btn-box__back
+  -#       = link_to :back, class: "white-btn margin-left-40 text-line-none" do
+  -#         もどる  

--- a/app/views/books/edit.html.haml
+++ b/app/views/books/edit.html.haml
@@ -1,0 +1,1 @@
+= render 'books/book'

--- a/app/views/books/index.html.haml
+++ b/app/views/books/index.html.haml
@@ -1,3 +1,5 @@
+= link_to "書籍を登録する", new_book_path
+
 .wrapper
   .contents
     .contents__all
@@ -8,14 +10,14 @@
           = link_to book_path(book.id) do
             .content
               .content__image
-                = image_tag book.image_url, alt: '', height: '200', width: '150', class: ''
+                = image_tag book.image.url, alt: '', height: '200', width: '150', class: ''
               .content__in
                 .content__in__title
                   = book.title
                 .content__in__author
                   = "著者: #{book.author}"
                 .content__in__explain
-                  = "出版社: #{book.publisher_name}"
+                  = "出版社: #{book.publisher}"
                 .content__in__user-name
                   = "投稿者: #{book.user.nickname}"
 

--- a/app/views/books/new.html.haml
+++ b/app/views/books/new.html.haml
@@ -1,2 +1,1 @@
-- if @books.present?
-  = render 'books/book'
+= render 'books/book'

--- a/app/views/books/show.html.haml
+++ b/app/views/books/show.html.haml
@@ -5,8 +5,7 @@
   .main_area
     .main_area__image
       .img_box
-        = link_to @book.url do
-          = image_tag @book.image_url, alt: '', height: '200', width: '150', class: ''
+        = image_tag @book.image.url, alt: '', height: '200', width: '150', class: ''
       .add-btn
     .main_area__info
       %h1.main_area__info__title
@@ -14,7 +13,7 @@
       .main_area__info__author
         = "著者：#{@book.author}"
       .main_area__info__publisher_name
-        = "出版社：#{@book.publisher_name}"
+        = "出版社：#{@book.publisher}"
       .main_area__info__rate
         レビュー点数入力予定
       - if user_signed_in? && current_user.id == @book.user_id

--- a/app/views/books/show.html.haml
+++ b/app/views/books/show.html.haml
@@ -18,4 +18,6 @@
         レビュー点数入力予定
       - if user_signed_in? && current_user.id == @book.user_id
         .d-btn
+          = link_to "編集", edit_book_path(@book)
+        .d-btn
           = link_to "削除", book_path(@book), method: :delete

--- a/app/views/devise/registrations/new.html.haml
+++ b/app/views/devise/registrations/new.html.haml
@@ -15,6 +15,10 @@
         %br/
         = f.email_field :email, autofocus: true, autocomplete: "email",class:"field__box"
       .field
+        = f.label :birth_day
+        %br/
+        = f.date_select :birth_day, prompt: "---",start_year:2020, end_year:1920, class: ""
+      .field
         = f.label :password
         - if @minimum_password_length
           %em

--- a/app/views/devise/registrations/new.html.haml
+++ b/app/views/devise/registrations/new.html.haml
@@ -11,6 +11,10 @@
         %br/
         = f.text_field :nickname, autofocus: true,  placeholder: "例）ニックネーム", class:"field__box"
       .field
+        = f.label :image
+        %br/
+        = f.file_field :image
+      .field
         = f.label :email
         %br/
         = f.email_field :email, autofocus: true, autocomplete: "email",class:"field__box"

--- a/config/application.rb
+++ b/config/application.rb
@@ -10,6 +10,10 @@ module FavoriteBooks
   class Application < Rails::Application
     # Initialize configuration defaults for originally generated Rails version.
     config.load_defaults 5.2
+    config.time_zone = 'Asia/Tokyo'
+    config.active_record.default_timezone = :local
+    config.i18n.default_locale = :ja
+    config.i18n.load_path += Dir[Rails.root.join('config', 'locales', '**', '*.yml').to_s]
 
     # Settings in config/environments/* take precedence over those specified here.
     # Application configuration can go into files in config/initializers

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -1,0 +1,287 @@
+---
+ja:
+  activerecord:
+    errors:
+      messages:
+        record_invalid: 'バリデーションに失敗しました: %{errors}'
+        restrict_dependent_destroy:
+          has_one: "%{record}が存在しているので削除できません"
+          has_many: "%{record}が存在しているので削除できません"
+  date:
+    abbr_day_names:
+    - 日
+    - 月
+    - 火
+    - 水
+    - 木
+    - 金
+    - 土
+    abbr_month_names:
+    - 
+    - 1月
+    - 2月
+    - 3月
+    - 4月
+    - 5月
+    - 6月
+    - 7月
+    - 8月
+    - 9月
+    - 10月
+    - 11月
+    - 12月
+    day_names:
+    - 日曜日
+    - 月曜日
+    - 火曜日
+    - 水曜日
+    - 木曜日
+    - 金曜日
+    - 土曜日
+    formats:
+      default: "%Y/%m/%d"
+      long: "%Y年%m月%d日(%a)"
+      short: "%m/%d"
+    month_names:
+    - 
+    - 1月
+    - 2月
+    - 3月
+    - 4月
+    - 5月
+    - 6月
+    - 7月
+    - 8月
+    - 9月
+    - 10月
+    - 11月
+    - 12月
+    order:
+    - :year
+    - :month
+    - :day
+  datetime:
+    distance_in_words:
+      about_x_hours:
+        one: 約1時間
+        other: 約%{count}時間
+      about_x_months:
+        one: 約1ヶ月
+        other: 約%{count}ヶ月
+      about_x_years:
+        one: 約1年
+        other: 約%{count}年
+      almost_x_years:
+        one: 1年弱
+        other: "%{count}年弱"
+      half_a_minute: 30秒前後
+      less_than_x_seconds:
+        one: 1秒以内
+        other: "%{count}秒未満"
+      less_than_x_minutes:
+        one: 1分以内
+        other: "%{count}分未満"
+      over_x_years:
+        one: 1年以上
+        other: "%{count}年以上"
+      x_seconds:
+        one: 1秒
+        other: "%{count}秒"
+      x_minutes:
+        one: 1分
+        other: "%{count}分"
+      x_days:
+        one: 1日
+        other: "%{count}日"
+      x_months:
+        one: 1ヶ月
+        other: "%{count}ヶ月"
+      x_years:
+        one: 1年
+        other: "%{count}年"
+    prompts:
+      second: 秒
+      minute: 分
+      hour: 時
+      day: 日
+      month: 月
+      year: 年
+  errors:
+    format: "%{attribute}%{message}"
+    messages:
+      accepted: を受諾してください
+      blank: を入力してください
+      confirmation: と%{attribute}の入力が一致しません
+      empty: を入力してください
+      equal_to: は%{count}にしてください
+      even: は偶数にしてください
+      exclusion: は予約されています
+      greater_than: は%{count}より大きい値にしてください
+      greater_than_or_equal_to: は%{count}以上の値にしてください
+      inclusion: を選択してください
+      invalid: は不正な値です
+      less_than: は%{count}より小さい値にしてください
+      less_than_or_equal_to: は%{count}以下の値にしてください
+      model_invalid: 'バリデーションに失敗しました: %{errors}'
+      not_a_number: は数値で入力してください
+      not_an_integer: は整数で入力してください
+      odd: は奇数にしてください
+      other_than: は%{count}以外の値にしてください
+      present: は入力しないでください
+      required: を入力してください
+      taken: はすでに存在します
+      too_long: は%{count}文字以内で入力してください
+      too_short: は%{count}文字以上で入力してください
+      wrong_length: は%{count}文字で入力してください
+    template:
+      body: 次の項目を確認してください
+      header:
+        one: "%{model}にエラーが発生しました"
+        other: "%{model}に%{count}個のエラーが発生しました"
+  helpers:
+    select:
+      prompt: 選択してください
+    submit:
+      create: 出品する
+      submit: 保存する
+      update: 変更する
+  number:
+    currency:
+      format:
+        delimiter: ","
+        format: "%n%u"
+        precision: 0
+        separator: "."
+        significant: false
+        strip_insignificant_zeros: false
+        unit: 円
+    format:
+      delimiter: ","
+      precision: 3
+      separator: "."
+      significant: false
+      strip_insignificant_zeros: false
+    human:
+      decimal_units:
+        format: "%n %u"
+        units:
+          billion: 十億
+          million: 百万
+          quadrillion: 千兆
+          thousand: 千
+          trillion: 兆
+          unit: ''
+      format:
+        delimiter: ''
+        precision: 3
+        significant: true
+        strip_insignificant_zeros: true
+      storage_units:
+        format: "%n%u"
+        units:
+          byte: バイト
+          eb: EB
+          gb: GB
+          kb: KB
+          mb: MB
+          pb: PB
+          tb: TB
+    percentage:
+      format:
+        delimiter: ''
+        format: "%n%"
+    precision:
+      format:
+        delimiter: ''
+  support:
+    array:
+      last_word_connector: "、"
+      two_words_connector: "、"
+      words_connector: "、"
+  time:
+    am: 午前
+    formats:
+      default: "%Y年%m月%d日(%a) %H時%M分%S秒 %z"
+      long: "%Y/%m/%d %H:%M"
+      short: "%m/%d %H:%M"
+    pm: 午後
+  enums:
+    book:
+      category:
+        "-----": "-----"
+        novel: "小説"
+        management: "ビジネス"
+        economy: "政治・経済"
+        finance: "金融・ファイナンス"
+        history: "歴史"
+        motivation: "自己啓発"
+        comic: "漫画"
+        etc: "その他"
+    impression:
+      read_day:
+        "-----": "-----"
+        one_day: "1日"
+        two_three_days: "2日〜3日"
+        one_week: "1週間"
+        two_four_weeks: "2週間〜4週間"
+        one_month_over: "1ヶ月以上"
+      interest:
+        "-----": "-----"
+        one_point: "１点"
+        two_points: "２点"
+        three_points: "３点"
+        four_points: "４点"
+        five_points: "５点"
+      impressed:
+        "-----": "-----"
+        one_point: "１点"
+        two_points: "２点"
+        three_points: "３点"
+        four_points: "４点"
+        five_points: "５点"
+      awareness:
+        "-----": "-----"
+        one_point: "１点"
+        two_points: "２点"
+        three_points: "３点"
+        four_points: "４点"
+        five_points: "５点"
+      impact:
+        "-----": "-----"
+        one_point: "１点"
+        two_points: "２点"
+        three_points: "３点"
+        four_points: "４点"
+        five_points: "５点"
+      practice:
+        "-----": "-----"
+        one_point: "１点"
+        two_points: "２点"
+        three_points: "３点"
+        four_points: "４点"
+        five_points: "５点"
+      knowledge:
+        "-----": "-----"
+        one_point: "１点"
+        two_points: "２点"
+        three_points: "３点"
+        four_points: "４点"
+        five_points: "５点"
+      rating:
+        "-----": "-----"
+        one_point: "１点"
+        two_points: "２点"
+        three_points: "３点"
+        four_points: "４点"
+        five_points: "５点"
+      reread_timing:
+        "-----": "-----"
+        knowledge: "知識を付けたい時"
+        motivation: "モチベーションをあげたい時"
+        decision: "なにか決断をする時"
+        stress: "ストレスが溜まっている時"
+        feel_down: "落ち込んでいる時"
+        lost_love: "失恋した時"
+        diversion: "気分転換したい時"
+        relax: "リラックスしたい時"
+        nothing_special: "特になし"

--- a/db/migrate/20200529232506_create_books.rb
+++ b/db/migrate/20200529232506_create_books.rb
@@ -1,13 +1,13 @@
 class CreateBooks < ActiveRecord::Migration[5.2]
   def change
     create_table :books do |t|
-      t.string :title, null: false
-      t.string :author
-      t.text :explain
-      t.string :url
-      t.bigint :isbn
-      t.string :image_url
-      t.string :publisher_name
+      t.string  :title, null: false
+      t.string  :author, null: false
+      t.string  :publisher, null: false
+      t.integer :category, null: false
+      t.integer :status, null: false, default: 0
+      t.string  :image
+      t.date    :buy_date, null: false
       t.timestamps
     end
   end

--- a/db/migrate/20200614102649_devise_create_users.rb
+++ b/db/migrate/20200614102649_devise_create_users.rb
@@ -7,6 +7,8 @@ class DeviseCreateUsers < ActiveRecord::Migration[5.2]
       t.string :nickname,           null: false
       t.string :email,              null: false, default: ""
       t.string :encrypted_password, null: false, default: ""
+      t.date   :birthday,           null: false
+      t.string :image
 
       ## Recoverable
       t.string   :reset_password_token

--- a/db/migrate/20200614102649_devise_create_users.rb
+++ b/db/migrate/20200614102649_devise_create_users.rb
@@ -7,7 +7,7 @@ class DeviseCreateUsers < ActiveRecord::Migration[5.2]
       t.string :nickname,           null: false
       t.string :email,              null: false, default: ""
       t.string :encrypted_password, null: false, default: ""
-      t.date   :birthday,           null: false
+      t.date   :birth_day,          null: false
       t.string :image
 
       ## Recoverable

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -14,12 +14,12 @@ ActiveRecord::Schema.define(version: 2020_06_16_144049) do
 
   create_table "books", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
     t.string "title", null: false
-    t.string "author"
-    t.text "explain"
-    t.string "url"
-    t.bigint "isbn"
-    t.string "image_url"
-    t.string "publisher_name"
+    t.string "author", null: false
+    t.string "publisher", null: false
+    t.integer "category", null: false
+    t.integer "status", default: 0, null: false
+    t.string "image"
+    t.date "buy_date", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.bigint "user_id", null: false
@@ -30,6 +30,8 @@ ActiveRecord::Schema.define(version: 2020_06_16_144049) do
     t.string "nickname", null: false
     t.string "email", default: "", null: false
     t.string "encrypted_password", default: "", null: false
+    t.date "birthday", null: false
+    t.string "image"
     t.string "reset_password_token"
     t.datetime "reset_password_sent_at"
     t.datetime "remember_created_at"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -30,7 +30,7 @@ ActiveRecord::Schema.define(version: 2020_06_16_144049) do
     t.string "nickname", null: false
     t.string "email", default: "", null: false
     t.string "encrypted_password", default: "", null: false
-    t.date "birthday", null: false
+    t.date "birth_day", null: false
     t.string "image"
     t.string "reset_password_token"
     t.datetime "reset_password_sent_at"


### PR DESCRIPTION
# what
書籍の投稿機能について、当初楽天APIを利用した書籍投稿・登録を検討したが、'carrierwave'を利用した画像投稿へと仕様を変更した。

# why
設計を考えた際に、カテゴリー登録や書籍購入日の登録等で、上記仕様の方が柔軟に投稿フォームを作成できると考えたため。

## その他
userのアバター投稿もできるよう変更した。
※この時点では、signup時に画像投稿可のみの設定とした。
　編集、ユーザーページは別ブランチで対応する。

